### PR TITLE
Plot Improvements

### DIFF
--- a/toytools/plot.py
+++ b/toytools/plot.py
@@ -28,7 +28,7 @@ def get_common_images_range(images, margin = 0.3):
 
     return (vmin, vmax)
 
-def default_image_plot(ax, image, vmin = None, vmax = None):
+def default_image_plot(ax, image, vmin = None, vmax = None, symlog = False):
     """Plot toyzero `image` with default style."""
 
     drop_ticks(ax)
@@ -41,7 +41,11 @@ def default_image_plot(ax, image, vmin = None, vmax = None):
 
     # pylint: disable=no-member
     cmap = mpl.cm.seismic
-    norm = mpl.colors.TwoSlopeNorm(0, vmin, vmax)
+
+    if symlog:
+        norm = mpl.colors.SymLogNorm(linthresh = 1.0, vmin = vmin, vmax = vmax)
+    else:
+        norm = mpl.colors.TwoSlopeNorm(0, vmin, vmax)
 
     return ax.imshow(image, cmap = cmap, norm = norm)
 

--- a/toytools/plot.py
+++ b/toytools/plot.py
@@ -22,7 +22,7 @@ def get_common_images_range(images, margin = 0.3):
     vmax = max(vmax, 1)
     vmax = (1 + margin) * vmax
 
-    vmin = max([ np.min(image) for image in images ])
+    vmin = min([ np.min(image) for image in images ])
     vmin = min(vmin, -1)
     vmin = (1 + margin) * vmin
 


### PR DESCRIPTION
This PR contains two changes:
1. As Ray suggested, I took a look at the plot color range calculation and turned out there is indeed a bug. The first commit of this PR fixes that bug.
2. The second commit adds a symlog color normalization option to the `default_image_plot` function. The symlog normalization is very handy for cycle-GAN comparison plots.