### PR TITLE
Precrop fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,3 +185,20 @@ This script will load the toyzero image crops from the file
 plots under `/path/to/plot_dir`.
 
 
+## Extracting Image Crops
+
+Loading entire event images from the disk is a very slow process and could
+easily make the training CPU bound. To speed up image loading, one can add one
+more preprocessing step and extract image crops with the help of the `precrop`
+script. For example, running
+```
+python scripts/precrop /path/to/data/LABEL-U-512x512.csv /output/directory
+```
+
+will extract image crops according to the precomputed file
+`LABEL-U-512x512.csv` and save them as `.npz` files under `/output/directory`.
+
+The resulted crops can be later loaded with the help of the
+`PreCroppedToyzeroDataset` dataset.
+
+

--- a/scripts/precrop
+++ b/scripts/precrop
@@ -72,7 +72,10 @@ class CroppingExtractorWorker:
 
         crop = crop_image(image, crop_region)
         crop = (crop - sample.bkg)
-        path = os.path.join(savedir, sample.image)
+
+        basename, ext = os.path.splitext(sample.image)
+        fname = '%s_%dx%d%s' % (basename, sample.x, sample.y, ext)
+        path  = os.path.join(savedir, fname)
 
         np.savez_compressed(path, crop)
 


### PR DESCRIPTION
This PR fixes a bug in the `precrop` script that resulted in multiple crops of the same image to be saved to the same file. It also adds a usage example of the `precrop` script that @pphuangyi requested.