### PR TITLE
Per-Domain Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,25 @@ Below you will find a brief overview of each.
 
 
 ## PyTorch Datasets
-At this moment only two PyTorch Datasets are implemented:
+
+Logically, there are two classes of toyzero datasets:
+
+- Version 0 datasets: `SimpleToyzeroDataset`, `PreSimpleToyzeroDataset`,
+  `PreUnalignedToyzeroDataset`, `PreCroppedToyzeroDataset`. These datasets
+  return pairs of images, where the first element is from domain "a" ("fake"
+  domain) and the second is from domain "b" ("real" domain).
+
+  These datasets implement their own random sampling that is not easy to use in
+  a multiprocessing setting.
+
+- Version 1 datasets: `PreSimpleToyzeroDatasetV1`,
+  `PreCroppedToyzeroDatasetV1`.  These datasets are similar to their v0
+  counterparts, but return a single image, either from domain "a" or domain
+  "b", depending on how they were instantiated.
+
+  Version 1 datasets support only deterministic sampling and therefore require
+  a separate random sampler. But, on the upside, there are no surprises when
+  one uses these datasets in the multiprocessing setting.
 
 
 ### SimpleToyzeroDataset

--- a/scripts/precrop
+++ b/scripts/precrop
@@ -10,11 +10,14 @@ import tqdm
 import numpy  as np
 import pandas as pd
 
-from toytools.collect   import train_test_split, load_image
+from toytools.collect import train_val_test_split, load_image
+from toytools.consts  import (
+    DIR_FAKE, DIR_REAL, SPLIT_TRAIN, SPLIT_VAL, SPLIT_TEST
+)
 from toytools.transform import crop_image
 
 def parse_cmdargs():
-    parser = argparse.ArgumentParser("View toyzero dataset")
+    parser = argparse.ArgumentParser("Precompute crops for toyzero dataset")
 
     parser.add_argument(
         'path',
@@ -49,6 +52,17 @@ def parse_cmdargs():
         '--val-size',
         default = 0.2,
         dest    = 'val_size',
+        help    = (
+            'Size of the validation dataset.'
+            'If val-size <= 1, then it is interpreted as a fraction'
+        ),
+        type    = float,
+    )
+
+    parser.add_argument(
+        '--test-size',
+        default = 0,
+        dest    = 'test_size',
         help    = (
             'Size of the test dataset.'
             'If val-size <= 1, then it is interpreted as a fraction'
@@ -89,17 +103,19 @@ class CroppingExtractorWorker:
 def load_dataset(path):
     return pd.read_csv(path, index_col = 'index')
 
-def split_into_train_test_parts(df, val_size, shuffle, seed):
+def split_into_parts(df, val_size, test_size, shuffle, seed):
     prg = None
 
     if shuffle:
         prg = np.random.default_rng(seed)
 
-    train_indices, test_indices = train_test_split(
-        len(df), val_size, shuffle, prg
+    train_indices, val_indices, test_indices = train_val_test_split(
+        len(df), val_size, test_size, shuffle, prg
     )
 
-    return (df.iloc[train_indices], df.iloc[test_indices])
+    return (
+        df.iloc[train_indices], df.iloc[val_indices], df.iloc[test_indices]
+    )
 
 def extract_crops(data_root, df, savedir_fake, savedir_real):
     os.makedirs(savedir_fake, exist_ok = True)
@@ -117,29 +133,33 @@ def extract_crops(data_root, df, savedir_fake, savedir_real):
 
     progbar.close()
 
-def extract(data_root, df_train, df_val, outdir):
-    savedir_train_fake = os.path.join(outdir, 'train', 'fake')
-    savedir_train_real = os.path.join(outdir, 'train', 'real')
-    savedir_val_fake   = os.path.join(outdir, 'val', 'fake')
-    savedir_val_real   = os.path.join(outdir, 'val', 'real')
-
+def extract(data_root, df_train, df_val, df_test, outdir):
     print("Extracting Training Crops")
-    extract_crops(data_root, df_train, savedir_train_fake, savedir_train_real)
+    dir_fake = os.path.join(outdir, SPLIT_TRAIN, DIR_FAKE)
+    dir_real = os.path.join(outdir, SPLIT_TRAIN, DIR_REAL)
+    extract_crops(data_root, df_train, dir_fake, dir_real)
 
     print("Extracting Validation Crops")
-    extract_crops(data_root, df_val,   savedir_val_fake,   savedir_val_real)
+    dir_fake = os.path.join(outdir, SPLIT_VAL, DIR_FAKE)
+    dir_real = os.path.join(outdir, SPLIT_VAL, DIR_REAL)
+    extract_crops(data_root, df_val, dir_fake, dir_real)
+
+    print("Extracting Test Crops")
+    dir_fake = os.path.join(outdir, SPLIT_TEST, DIR_FAKE)
+    dir_real = os.path.join(outdir, SPLIT_TEST, DIR_REAL)
+    extract_crops(data_root, df_test, dir_fake, dir_real)
 
 def main():
     cmdargs = parse_cmdargs()
 
     df = load_dataset(cmdargs.path)
 
-    df_train, df_val = split_into_train_test_parts(
-        df, cmdargs.val_size, cmdargs.shuffle, cmdargs.seed
+    df_train, df_val, df_test = split_into_parts(
+        df, cmdargs.val_size, cmdargs.test_size, cmdargs.shuffle, cmdargs.seed
     )
 
     data_root = os.path.dirname(cmdargs.path)
-    extract(data_root, df_train, df_val, cmdargs.outdir)
+    extract(data_root, df_train, df_val, df_test, cmdargs.outdir)
 
 if __name__ == '__main__':
     main()

--- a/scripts/view_dataset
+++ b/scripts/view_dataset
@@ -57,47 +57,47 @@ def parse_cmdargs():
     return parser.parse_args()
 
 # pylint: disable=too-many-arguments
-def plot_image_pair(
-    img_fake, img_real, cmap, log, symmetric, vertical = False
-):
+def plot_images(images, cmap, log, symmetric, vertical = False):
     subplots_kwargs = {
         'sharex' : True, 'sharey' : True, 'constrained_layout' : True,
     }
 
+    n = len(images)
+
     if vertical:
-        f, axs = plt.subplots(2, 1, **subplots_kwargs)
+        f, axs = plt.subplots(n, 1, **subplots_kwargs)
     else:
-        f, axs = plt.subplots(1, 2, **subplots_kwargs)
+        f, axs = plt.subplots(1, n, **subplots_kwargs)
+
+    if n == 1:
+        axs = [ axs, ]
 
     plot_kwargs = {
-        'vrange' : get_common_images_range(
-            (img_fake, img_real), symmetric = symmetric
-        ),
+        'vrange' : get_common_images_range(images, symmetric = symmetric),
         'cmap'   : cmap,
         'log'    : log,
     }
 
-    aximg_fake = default_image_plot(axs[0], img_fake, **plot_kwargs)
-    _          = default_image_plot(axs[1], img_real, **plot_kwargs)
-
-    axs[0].set_title('Fake')
-    axs[1].set_title('Real')
+    for (ax, image) in zip(axs, images):
+        aximg = default_image_plot(ax, image, **plot_kwargs)
 
     if vertical:
-        f.colorbar(aximg_fake, ax = axs, location = 'right')
+        f.colorbar(aximg, ax = axs, location = 'right')
     else:
-        f.colorbar(aximg_fake, ax = axs, location = 'bottom')
+        f.colorbar(aximg, ax = axs, location = 'bottom')
 
     return f, axs
 
 # pylint: disable=too-many-arguments
 def plot_single_sample(dataset, index, cmap, log, symmetric, plotdir, ext):
-    img_fake, img_real = dataset[index]
-    vertical = (img_fake.shape[1] > img_fake.shape[0])
+    images = dataset[index]
 
-    f, _ax = plot_image_pair(
-        img_fake, img_real, cmap, log, symmetric, vertical
-    )
+    if not isinstance(images, (tuple, list)):
+        images = [ images, ]
+
+    vertical = (images[0].shape[1] > images[0].shape[0])
+
+    f, _ax = plot_images(images, cmap, log, symmetric, vertical)
     f.suptitle("Index: %d" % index)
 
     if plotdir is None:

--- a/toytools/collect.py
+++ b/toytools/collect.py
@@ -119,6 +119,60 @@ def load_image(root : str, is_fake : bool, name : str) -> np.ndarray:
     with np.load(path) as f:
         return f[f.files[0]]
 
+def train_val_test_split(
+    n         : int,
+    val_size  : Union[int, float],
+    test_size : Union[int, float],
+    shuffle   : bool,
+    prg       : np.random.Generator,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Split dataset of size `n` into training/val/test parts.
+
+    Parameters
+    ----------
+    n : int
+        Size of the dataset to split.
+    val_size : int or float
+        Fraction of the dataset that will be used as a val sample.
+        If `val_size` <= 1, then it is treated as a fraction, i.e.
+        (size of test sample) = `val_size` * (size of toyzero dataset)
+        Otherwise, (size of val sample) = `val_size`.
+    test_size : int or float
+        Fraction of the dataset that will be used as a test sample.
+        If `test_size` <= 1, then it is treated as a fraction, i.e.
+        (size of test sample) = `test_size` * (size of toyzero dataset)
+        Otherwise, (size of test sample) = `test_size`.
+    shuffle : bool
+        Whether to shuffle dataset
+    prg : np.random.Generator
+        RNG that will be used for shuffling the dataset.
+        This parameter has no effect if `shuffle` is False.
+
+    Returns
+    -------
+    (train_indices, val_indices, test_indices) : (ndarray, ndarray, ndarray)
+        Indices of training/val/test samples.
+
+    """
+    indices = np.arange(n)
+
+    if shuffle:
+        prg.shuffle(indices)
+
+    if test_size <= 1:
+        test_size = int(len(indices) * test_size)
+
+    if val_size <= 1:
+        val_size = int(len(indices) * val_size)
+
+    train_size = max(0, int(len(indices) - val_size - test_size))
+
+    train_indices = indices[:train_size]
+    val_indices   = indices[train_size:train_size+val_size]
+    test_indices  = indices[train_size+val_size:]
+
+    return (train_indices, val_indices, test_indices)
+
 def train_test_split(
     n         : int,
     test_size : Union[int, float],
@@ -148,18 +202,10 @@ def train_test_split(
         Indices of training and validation samples.
 
     """
-    indices = np.arange(n)
 
-    if shuffle:
-        prg.shuffle(indices)
-
-    if test_size <= 1:
-        test_size = int(len(indices) * test_size)
-
-    train_size = max(0, int(len(indices) - test_size))
-
-    train_indices = indices[:train_size]
-    test_indices  = indices[train_size:]
+    train_indices, _val_indices, test_indices = train_val_test_split(
+        n, val_size = 0, test_size = test_size, shuffle = shuffle, prg = prg
+    )
 
     return (train_indices, test_indices)
 

--- a/toytools/collect.py
+++ b/toytools/collect.py
@@ -6,8 +6,7 @@ import re
 from typing import List, Tuple, Optional, Set, Union
 import numpy as np
 
-DIR_FAKE = 'fake'
-DIR_REAL = 'real'
+from .consts import DIR_FAKE, DIR_REAL
 
 def find_images_in_dir(path : str) -> List[str]:
     """Return sorted list of '*.npz' files in `path`"""

--- a/toytools/consts.py
+++ b/toytools/consts.py
@@ -1,0 +1,9 @@
+"""Common constants for toytools package"""
+
+DIR_FAKE = 'fake'
+DIR_REAL = 'real'
+
+SPLIT_TRAIN = 'train'
+SPLIT_TEST  = 'test'
+SPLIT_VAL   = 'val'
+

--- a/toytools/datasets/funcs.py
+++ b/toytools/datasets/funcs.py
@@ -7,26 +7,20 @@ from .preunaligned_toyzero    import PreUnalignedToyzeroDataset
 from .precropped_toyzero      import PreCroppedToyzeroDataset
 from .precropped_toyzero_v1   import PreCroppedToyzeroDatasetV1
 
+DATASET_DICT = {
+    'toyzero-simple'        : SimpleToyzeroDataset,
+    'toyzero-presimple'     : PreSimpleToyzeroDataset,
+    'toyzero-preunaligned'  : PreUnalignedToyzeroDataset,
+    'toyzero-precropped'    : PreCroppedToyzeroDataset,
+    'toyzero-precropped-v1' : PreCroppedToyzeroDatasetV1,
+    'toyzero-presimple-v1'  : PreSimpleToyzeroDatasetV1,
+}
+
 def get_toyzero_dataset(name, path, **data_args):
     """Return toyzero dataset based on its name"""
 
-    if name == 'toyzero-simple':
-        return SimpleToyzeroDataset(path, **data_args)
+    if name not in DATASET_DICT:
+        raise ValueError("Unknown dataset name: %s" % name)
 
-    if name == 'toyzero-presimple':
-        return PreSimpleToyzeroDataset(path, **data_args)
-
-    if name == 'toyzero-preunaligned':
-        return PreUnalignedToyzeroDataset(path, **data_args)
-
-    if name == 'toyzero-precropped':
-        return PreCroppedToyzeroDataset(path, **data_args)
-
-    if name == 'toyzero-precropped-v1':
-        return PreCroppedToyzeroDatasetV1(path, **data_args)
-
-    if name == 'toyzero-presimple-v1':
-        return PreSimpleToyzeroDatasetV1(path, **data_args)
-
-    raise ValueError("Unknown toyzero dataset name: %s" % name)
+    return DATASET_DICT[name](path, **data_args)
 

--- a/toytools/datasets/funcs.py
+++ b/toytools/datasets/funcs.py
@@ -1,9 +1,11 @@
 """Various helper functions to construct toyzero datasets."""
 
-from .simple_toyzero       import SimpleToyzeroDataset
-from .presimple_toyzero    import PreSimpleToyzeroDataset
-from .preunaligned_toyzero import PreUnalignedToyzeroDataset
-from .precropped_toyzero   import PreCroppedToyzeroDataset
+from .simple_toyzero          import SimpleToyzeroDataset
+from .presimple_toyzero       import PreSimpleToyzeroDataset
+from .presimple_toyzero_v1    import PreSimpleToyzeroDatasetV1
+from .preunaligned_toyzero    import PreUnalignedToyzeroDataset
+from .precropped_toyzero      import PreCroppedToyzeroDataset
+from .precropped_toyzero_v1   import PreCroppedToyzeroDatasetV1
 
 def get_toyzero_dataset(name, path, **data_args):
     """Return toyzero dataset based on its name"""
@@ -19,6 +21,12 @@ def get_toyzero_dataset(name, path, **data_args):
 
     if name == 'toyzero-precropped':
         return PreCroppedToyzeroDataset(path, **data_args)
+
+    if name == 'toyzero-precropped-v1':
+        return PreCroppedToyzeroDatasetV1(path, **data_args)
+
+    if name == 'toyzero-presimple-v1':
+        return PreSimpleToyzeroDatasetV1(path, **data_args)
 
     raise ValueError("Unknown toyzero dataset name: %s" % name)
 

--- a/toytools/datasets/generic_dataset.py
+++ b/toytools/datasets/generic_dataset.py
@@ -1,5 +1,14 @@
 # pylint: disable=missing-module-docstring
 
+from toytools.collect import DIR_FAKE, DIR_REAL
+
+DOMAIN_MAP = {
+    'a'    : DIR_FAKE,
+    'fake' : DIR_FAKE,
+    'b'    : DIR_REAL,
+    'real' : DIR_REAL,
+}
+
 class GenericDataset:
     """Abstract class for toyzero Dataset"""
 

--- a/toytools/datasets/precropped_toyzero_v1.py
+++ b/toytools/datasets/precropped_toyzero_v1.py
@@ -1,0 +1,51 @@
+# pylint: disable=missing-module-docstring
+import os
+import numpy as np
+
+from toytools.collect import find_images_in_dir
+from toytools.consts  import SPLIT_TRAIN, SPLIT_TEST, SPLIT_VAL
+from .generic_dataset import GenericDataset, DOMAIN_MAP
+
+class PreCroppedToyzeroDatasetV1(GenericDataset):
+    """Toyzero Dataset that loads precropped images.
+
+    Parameters
+    ----------
+    path : str
+        Path where the precropped toyzero dataset is located.
+    domain : str
+        Choices: 'a' ('real'), 'b' ('fake')
+    split : str
+        Choices: 'train', 'test', 'val'
+    transform : Callable or None,
+        Optional transformation to apply to images.
+        E.g. torchvision.transforms.RandomCrop.
+        Default: None
+    """
+
+    def __init__(self, path, domain, split, transform = None):
+        super().__init__(path)
+
+        assert domain in DOMAIN_MAP
+        assert split  in [ SPLIT_TRAIN, SPLIT_TEST, SPLIT_VAL ]
+
+        self._root      = os.path.join(path, split, DOMAIN_MAP[domain])
+        self._domain    = domain
+        self._split     = split
+        self._transform = transform
+        self._images    = find_images_in_dir(self._root)
+
+    def __len__(self):
+        return len(self._images)
+
+    def __getitem__(self, index):
+        fname = self._images[index]
+
+        with np.load(os.path.join(self._root, fname)) as f:
+            image = f[f.files[0]].astype(np.float32)
+
+        if self._transform is not None:
+            image = self._transform(image)
+
+        return image
+

--- a/toytools/datasets/presimple_toyzero_v1.py
+++ b/toytools/datasets/presimple_toyzero_v1.py
@@ -1,0 +1,119 @@
+# pylint: disable=missing-module-docstring
+import os
+import numpy as np
+import pandas as pd
+
+from toytools.collect   import train_val_test_split
+from toytools.transform import crop_image
+from toytools.consts    import SPLIT_TRAIN, SPLIT_VAL, SPLIT_TEST
+
+from .generic_dataset   import GenericDataset, DOMAIN_MAP
+
+class PreSimpleToyzeroDatasetV1(GenericDataset):
+    """Toyzero Dataset that loads images according to preprocessed list.
+
+    Parameters
+    ----------
+    path : str
+        Path where the toyzero dataset is located.
+    fname : str
+        Name of the file containing preprocessed list of toyzero images.
+        This should be located under `path`.
+    domain : str
+        Choices: 'a' ('real'), 'b' ('fake')
+    split : str
+        Choices: 'train', 'test', 'val'
+    shuffle : bool
+        Controls whether to shuffle the dataset before splitting it into
+        training/validation/test parts.
+        Default: True
+    seed : int
+        Seed used to initialize random number generators.
+        Default: 0
+    transform : Callable or None,
+        Optional transformation to apply to images.
+        E.g. torchvision.transforms.RandomCrop.
+        Default: None
+    val_size : float or int
+        Fraction of the toyzero dataset that will be used as a validation
+        sample. If val_size <= 1, then it is treated as a fraction, i.e.
+        (size of val sample) = `val_size` * (size of toyzero dataset)
+        Otherwise, (size of val sample) = `val_size`.
+        Default: 0.2
+    test_size : float or int
+        Fraction of the toyzero dataset that will be used as a test
+        sample. If test_size <= 1, then it is treated as a fraction, i.e.
+        (size of val sample) = `test_size` * (size of toyzero dataset)
+        Otherwise, (size of val sample) = `test_size`.
+        Default: 0.2
+    """
+
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self, path,
+        fname            = None,
+        split            = SPLIT_TRAIN,
+        domain           = 'a',
+        seed             = 0,
+        shuffle          = True,
+        transform        = None,
+        val_size         = 0.2,
+        test_size        = 0,
+    ):
+        super().__init__(path)
+
+        assert split  in [ SPLIT_TRAIN, SPLIT_VAL, SPLIT_TEST ]
+        assert domain in DOMAIN_MAP
+
+        self._domain    = domain
+        self._split     = split
+        self._seed      = seed
+        self._transform = transform
+        self._prg       = np.random.default_rng(seed)
+        self._val_size  = val_size
+        self._test_size = test_size
+        self._df        = None
+        self._root      = os.path.join(path, DOMAIN_MAP[domain])
+
+        df = pd.read_csv(os.path.join(path, fname), index_col = 'index')
+        self._split_dataset(df, shuffle)
+
+    def _split_dataset(self, df, shuffle):
+        """Split dataset into training/validation/test parts."""
+        train_indices, val_indices, test_indices = train_val_test_split(
+            len(df), self._val_size, self._test_size, shuffle, self._prg
+        )
+
+        if self._split == SPLIT_TRAIN:
+            indices = train_indices
+
+        elif self._split == SPLIT_VAL:
+            indices = val_indices
+
+        else:
+            indices = test_indices
+
+        self._df = df.iloc[indices]
+
+    def __len__(self):
+        return len(self._df)
+
+    def __getitem__(self, index):
+        sample = self._df.iloc[index]
+
+        with np.load(os.path.join(self._root, sample.image)) as f:
+            image = f[f.files[0]]
+
+        image = crop_image(
+            image, (sample.x, sample.y, sample.width, sample.height)
+        )
+
+        image = image - sample.bkg
+        image = image.astype(np.float32)
+
+        if self._transform is not None:
+            image = self._transform(image)
+
+        return image
+

--- a/toytools/parsers.py
+++ b/toytools/parsers.py
@@ -4,15 +4,16 @@ import json
 import re
 from typing import Optional
 
+from .datasets.funcs import DATASET_DICT
+
 def add_dataset_parser(parser):
     # pylint: disable=missing-function-docstring
+    datasets = list(DATASET_DICT.keys())
+
     parser.add_argument(
         '--dataset',
-        choices = [
-            'toyzero-simple', 'toyzero-presimple', 'toyzero-precropped',
-            'toyzero-preunaligned'
-        ],
-        default = 'toyzero-simple',
+        choices = datasets,
+        default = datasets[0],
         dest    = 'dataset',
         help    = 'type of the toyzero dataset to use',
         type    = str,
@@ -89,5 +90,4 @@ def parse_index_range(index : Optional[str], full_len : int) -> range:
     index_slice = slice(first, last)
 
     return range(*index_slice.indices(full_len))
-
 


### PR DESCRIPTION
Hi everyone,

Following our discussion of the Dataset/Dataloader [refactoring](https://github.com/LS4GAN/toygan/issues/63) I have implemented two new toyzero Datasets. These new datasets do not perform any sort of random sampling and therefore are robust when used in a multiprocessing setup. Additionally, instead of returning a pair of `(fake, real)` images they return a single image (either `fake` or `real`).

In addition to implementing the new datasets, this PR adds a few more changes:
* Adds support for a proper train/val/test separation: a5a4ec7a695bcf0b5fa3ee0f46817d8c39356e09, ea8752eb49d4ed705c1b04d443eba01eda724c12. (Previously, separation was supported only for train/test split)
* Modifies dataset viewer script to support new datasets 7d8f18a5aae77aaa4460587459eef2aa594274d6.
* plus a few small documentation, code structure changes.

Inviting: @brettviren, @YHRen, @pphuangyi, @HaiwangYu 