### PR TITLE
Implement Toyzero Cropping/Tiling Scripts (v2)

### DIFF
--- a/scripts/precrop
+++ b/scripts/precrop
@@ -134,20 +134,23 @@ def extract_crops(data_root, df, savedir_fake, savedir_real):
     progbar.close()
 
 def extract(data_root, df_train, df_val, df_test, outdir):
-    print("Extracting Training Crops")
-    dir_fake = os.path.join(outdir, SPLIT_TRAIN, DIR_FAKE)
-    dir_real = os.path.join(outdir, SPLIT_TRAIN, DIR_REAL)
-    extract_crops(data_root, df_train, dir_fake, dir_real)
+    if len(df_train) > 0:
+        print("Extracting Training Crops")
+        dir_fake = os.path.join(outdir, SPLIT_TRAIN, DIR_FAKE)
+        dir_real = os.path.join(outdir, SPLIT_TRAIN, DIR_REAL)
+        extract_crops(data_root, df_train, dir_fake, dir_real)
 
-    print("Extracting Validation Crops")
-    dir_fake = os.path.join(outdir, SPLIT_VAL, DIR_FAKE)
-    dir_real = os.path.join(outdir, SPLIT_VAL, DIR_REAL)
-    extract_crops(data_root, df_val, dir_fake, dir_real)
+    if len(df_val):
+        print("Extracting Validation Crops")
+        dir_fake = os.path.join(outdir, SPLIT_VAL, DIR_FAKE)
+        dir_real = os.path.join(outdir, SPLIT_VAL, DIR_REAL)
+        extract_crops(data_root, df_val, dir_fake, dir_real)
 
-    print("Extracting Test Crops")
-    dir_fake = os.path.join(outdir, SPLIT_TEST, DIR_FAKE)
-    dir_real = os.path.join(outdir, SPLIT_TEST, DIR_REAL)
-    extract_crops(data_root, df_test, dir_fake, dir_real)
+    if len(df_test):
+        print("Extracting Test Crops")
+        dir_fake = os.path.join(outdir, SPLIT_TEST, DIR_FAKE)
+        dir_real = os.path.join(outdir, SPLIT_TEST, DIR_REAL)
+        extract_crops(data_root, df_test, dir_fake, dir_real)
 
 def main():
     cmdargs = parse_cmdargs()

--- a/scripts/precrop
+++ b/scripts/precrop
@@ -10,7 +10,7 @@ import tqdm
 import numpy  as np
 import pandas as pd
 
-from toytools.collect import train_val_test_split, load_image
+from toytools.collect import train_val_test_split, load_toyzero_image
 from toytools.consts  import (
     DIR_FAKE, DIR_REAL, SPLIT_TRAIN, SPLIT_VAL, SPLIT_TEST
 )
@@ -94,8 +94,8 @@ class CroppingExtractorWorker:
         np.savez_compressed(path, crop)
 
     def __call__(self, sample):
-        image_fake = load_image(self._data_root, True,  sample.image)
-        image_real = load_image(self._data_root, False, sample.image)
+        image_fake = load_toyzero_image(self._data_root, True,  sample.image)
+        image_real = load_toyzero_image(self._data_root, False, sample.image)
 
         self._extract_crop(image_fake, sample, self._savedir_fake)
         self._extract_crop(image_real, sample, self._savedir_real)

--- a/scripts/preprocess
+++ b/scripts/preprocess
@@ -14,7 +14,8 @@ import numpy as np
 import pandas as pd
 
 from toytools.collect import (
-    collect_toyzero_images, filter_parsed_images, parse_images, load_image
+    collect_toyzero_images, filter_parsed_images, parse_images,
+    load_toyzero_image
 )
 from toytools.transform import (
     get_background_value_fast, is_image_empty, try_find_region_with_signal
@@ -52,7 +53,7 @@ class CroppingWorker:
         """Return a list of preprocessed regions of a parsed image"""
         index, parsed_image = index_and_parsed_image
 
-        image     = load_image(self._path, True, parsed_image[0])
+        image     = load_toyzero_image(self._path, True, parsed_image[0])
         bkg_value = get_background_value_fast(image)
 
         if is_image_empty(image, bkg_value, self._min_signal):

--- a/scripts/toyzero/center_crop
+++ b/scripts/toyzero/center_crop
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+"""Extract center crops from toyzero data"""
+# pylint: disable=missing-function-docstring
+
+import argparse
+import json
+import os
+import multiprocessing
+
+from collections import namedtuple
+from typing import List
+
+import numpy as np
+import tqdm
+
+from toytools.consts import DIR_FAKE, DIR_REAL
+from toytools.collect import (
+    ParsedImage, load_toyzero_image, collect_toyzero_images,
+    filter_parsed_images, parse_images
+)
+from toytools.transform import crop_image, get_background_value, is_image_empty
+
+Config = namedtuple(
+    'Config', [ 'root', 'outdir', 'apas', 'planes', 'shape', 'min_signal' ]
+)
+
+def parse_cmdargs():
+    parser = argparse.ArgumentParser(
+        "Extract center crops from toyzero dataset"
+    )
+
+    parser.add_argument(
+        'root',
+        help    = 'path to the toyzero dataset',
+        metavar = 'PATH',
+        type    = str,
+    )
+
+    parser.add_argument(
+        'outdir',
+        help    = 'directory where to save cropped dataset',
+        metavar = 'OUTDIR',
+        type    = str,
+    )
+
+    parser.add_argument(
+        '--apa',
+        default = None,
+        dest    = 'apas',
+        help    = 'APAs to select',
+        type    = int,
+        nargs   = '*',
+    )
+
+    parser.add_argument(
+        '--plane',
+        default = None,
+        dest    = 'planes',
+        help    = 'wire Planes to select',
+        choices = [ 'U', 'V', 'W', ],
+        nargs   = '*',
+    )
+
+    parser.add_argument(
+        '-s', '--shape',
+        default  = None,
+        dest     = 'shape',
+        help     = "shape of the crop 'HEIGHTxWIDTH'",
+        required = True,
+        type     = lambda s : tuple(int(x) for x in s.split('x'))
+    )
+
+    parser.add_argument(
+        '--min-signal',
+        default = 1,
+        dest    = 'min_signal',
+        help    = 'minimum number of signal pixels to consider image nonempty',
+        type    = int,
+    )
+
+
+    return parser.parse_args()
+
+class CroppingWorker:
+    # pylint: disable=missing-class-docstring
+
+    def __init__(self, config, outdir_real, outdir_fake):
+        self._root        = config.root
+        self._shape       = config.shape
+        self._min_signal  = config.min_signal
+        self._outdir_real = outdir_real
+        self._outdir_fake = outdir_fake
+
+    def _extract_crop(self, parsed_image, is_fake):
+        image     = load_toyzero_image(self._root, is_fake, parsed_image.fname)
+        bkg_value = get_background_value(image)
+
+        (H, W) = image.shape
+        y0     = (H - self._shape[0]) // 2
+        x0     = (W - self._shape[1]) // 2
+
+        crop = crop_image(image, crop_region = (y0, x0, *self._shape))
+        crop = (crop - bkg_value)
+
+        return crop
+
+    def _are_images_above_threshold(self, images):
+        for image in images:
+            if is_image_empty(
+                image, bkg_value = 0, min_signal = self._min_signal
+            ):
+                return False
+
+        return True
+
+    @staticmethod
+    def save_crop(crop, outdir, parsed_image):
+        path = os.path.join(outdir, parsed_image.fname)
+        np.savez_compressed(path, crop)
+
+    def __call__(self, parsed_image):
+        crop_fake = self._extract_crop(parsed_image, is_fake = True)
+        crop_real = self._extract_crop(parsed_image, is_fake = False)
+
+        crops = [ crop_fake, crop_real ]
+        if not self._are_images_above_threshold(crops):
+            return
+
+        CroppingWorker.save_crop(crop_fake, self._outdir_fake, parsed_image)
+        CroppingWorker.save_crop(crop_real, self._outdir_real, parsed_image)
+
+def create_config_from_cmdargs(cmdargs):
+    def optional_map(fn, x):
+        if x is None:
+            return None
+
+        return fn(x)
+
+    return Config(
+        root       = cmdargs.root,
+        outdir     = cmdargs.outdir,
+        apas       = optional_map(set, cmdargs.apas),
+        planes     = optional_map(set, cmdargs.planes),
+        shape      = cmdargs.shape,
+        min_signal = cmdargs.min_signal,
+    )
+
+def prepare_image_list(config : Config) -> List[ParsedImage]:
+    images = collect_toyzero_images(config.root)
+    parsed_images = parse_images(images)
+
+    parsed_images = filter_parsed_images(
+        parsed_images, config.apas, config.planes
+    )
+
+    return parsed_images
+
+def extract_images(config : Config, parsed_images : List[ParsedImage]) -> None:
+    outdir_real = os.path.join(config.outdir, DIR_REAL)
+    outdir_fake = os.path.join(config.outdir, DIR_FAKE)
+
+    os.makedirs(outdir_real, exist_ok = True)
+    os.makedirs(outdir_fake, exist_ok = True)
+
+    progbar = tqdm.tqdm(
+        desc = 'Cropping', total = len(parsed_images), dynamic_ncols = True
+    )
+
+    worker = CroppingWorker(config, outdir_real, outdir_fake)
+
+    with multiprocessing.Pool() as pool:
+        for _ in pool.imap_unordered(worker, parsed_images):
+            progbar.update()
+
+    progbar.close()
+
+def save_config(config : Config) -> None:
+    os.makedirs(config.outdir, exist_ok = True)
+    config_path = os.path.join(config.outdir, 'config.json')
+
+    config_dict = {
+        'script'     : 'toyzero/center_crop',
+        'apas'       : str(config.apas),
+        'min_signal' : config.min_signal,
+        'shape'      : config.shape,
+        'planes'     : str(config.planes),
+    }
+
+    with open(config_path, 'wt') as f:
+        json.dump(config_dict, f, indent = 4)
+
+def main():
+    cmdargs = parse_cmdargs()
+    config  = create_config_from_cmdargs(cmdargs)
+
+    if os.path.exists(config.outdir):
+        raise RuntimeError(
+            f"Output directory {config.outdir} exists. Refusing to overwrite."
+        )
+
+    print("Collecting Images...")
+    parsed_images = prepare_image_list(config)
+
+    print("Extracting center crops...")
+    extract_images(config, parsed_images)
+    save_config(config)
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/toyzero/tile_crop
+++ b/scripts/toyzero/tile_crop
@@ -1,0 +1,217 @@
+#!/usr/bin/env python
+"""Tile crop toyzero data"""
+# pylint: disable=missing-function-docstring
+
+import argparse
+import json
+import itertools
+import os
+import multiprocessing
+
+from collections import namedtuple
+
+import numpy as np
+import tqdm
+
+from toytools.collect import (
+    collect_split_toyzero_images, validate_image_hierarchy_paired
+)
+from toytools.transform import crop_image, get_background_value, is_image_empty
+
+Config = namedtuple('Config', [ 'root', 'outdir', 'shape', 'min_signal' ])
+
+def parse_cmdargs():
+    parser = argparse.ArgumentParser("Tile toyzero crops")
+
+    parser.add_argument(
+        'path',
+        help    = 'path to the cropped dataset',
+        metavar = 'PATH',
+        type    = str,
+    )
+
+    parser.add_argument(
+        'outdir',
+        help    = 'directory where to save tiled dataset',
+        metavar = 'OUTDIR',
+        type    = str,
+    )
+
+    parser.add_argument(
+        '-s', '--shape',
+        default  = None,
+        dest     = 'shape',
+        help     = "shape of the crop 'HEIGHTxWIDTH'",
+        required = True,
+        type     = lambda s : tuple(int(x) for x in s.split('x'))
+    )
+
+    parser.add_argument(
+        '--min-signal',
+        default = 10,
+        dest    = 'min_signal',
+        help    = 'minimum number of signal pixels to consider image nonempty',
+        type    = int,
+    )
+
+    return parser.parse_args()
+
+class TilingWorker:
+    # pylint: disable=missing-class-docstring
+
+    def __init__(self, config, split_dir, domain_dirs):
+        # pylint: disable=too-many-arguments
+        self._outdir      = config.outdir
+        self._root        = config.root
+        self._shape       = config.shape
+        self._min_signal  = config.min_signal
+        self._split_dir   = split_dir
+        self._domain_dirs = domain_dirs
+
+    def _get_output_path(self, domain_dir, fname, crop_index):
+        savedir = os.path.join(self._outdir, self._split_dir, domain_dir)
+
+        crop_fname, ext = os.path.splitext(fname)
+        crop_fname = crop_fname + f'_tile_{crop_index}' + ext
+
+        return os.path.join(savedir, crop_fname)
+
+    @staticmethod
+    def load_toyzero_image(path):
+        with np.load(path) as f:
+            image = f[f.files[0]]
+
+        bkg_value = get_background_value(image)
+
+        return (image - bkg_value)
+
+    @staticmethod
+    def get_images_shape(images):
+        if len(images) == 0:
+            return True
+
+        shapes = [ image.shape for image in images ]
+        return shapes[0]
+
+    def _are_images_above_threshold(self, images):
+        for image in images:
+            if is_image_empty(
+                image, bkg_value = 0, min_signal = self._min_signal
+            ):
+                return False
+
+        return True
+
+    def _get_grid_shape(self, image_shape):
+        (H, W) = image_shape
+        m, rm  = divmod(H, self._shape[0])
+        n, rn  = divmod(W, self._shape[1])
+
+        if (rm != 0) or (rn != 0):
+            raise RuntimeError(
+                f"Image size {image_shape} is not divisible by crop size"
+                f" {self._shape}"
+            )
+
+        return (m, n)
+
+    def _run_tiling_loop(self, m, n, images, fname):
+        for (j, i) in itertools.product(range(m), range(n)):
+            y0 = j * self._shape[0]
+            x0 = i * self._shape[1]
+
+            crop_index  = j * n + i
+            crop_region = (y0, x0, *self._shape)
+
+            crops = [
+                crop_image(image, crop_region = crop_region)
+                    for image in images
+            ]
+
+            if not self._are_images_above_threshold(crops):
+                continue
+
+            for (domain_dir, crop) in zip(self._domain_dirs, crops):
+                path = self._get_output_path(domain_dir, fname, crop_index)
+                np.savez_compressed(path, crop)
+
+    def __call__(self, fname):
+        paths = [
+            os.path.join(self._root, self._split_dir, d, fname)
+                for d in self._domain_dirs
+        ]
+        images = [ TilingWorker.load_toyzero_image(path) for path in paths ]
+
+        shape = TilingWorker.get_images_shape(images)
+        m, n  = self._get_grid_shape(shape)
+
+        self._run_tiling_loop(m, n, images, fname)
+
+def create_config_from_cmdargs(cmdargs):
+    return Config(
+        root       = cmdargs.path,
+        outdir     = cmdargs.outdir,
+        shape      = cmdargs.shape,
+        min_signal = cmdargs.min_signal,
+    )
+
+def prepare_output_directories(outdir, image_hierarchy):
+    for split_dir, image_dict in image_hierarchy.items():
+        split_path = os.path.join(outdir, split_dir)
+        os.makedirs(split_path, exist_ok = True)
+
+        for domain_dir in image_dict.keys():
+            domain_path = os.path.join(split_path, domain_dir)
+            os.makedirs(domain_path, exist_ok = True)
+
+def tile_images(config, image_hierarchy):
+    for (split_dir, image_dict) in image_hierarchy.items():
+        domains, domain_image_fnames = zip(*image_dict.items())
+
+        print(f"Tiling images in '{split_dir}'")
+
+        worker  = TilingWorker(config, split_dir, domains)
+        progbar = tqdm.tqdm(
+            desc = 'Tiling', total = len(domain_image_fnames[0]),
+            dynamic_ncols = True
+        )
+
+        with multiprocessing.Pool() as pool:
+            for _ in pool.imap_unordered(worker, domain_image_fnames[0]):
+                progbar.update()
+
+        progbar.close()
+
+def save_config(config):
+    config_path = os.path.join(config.outdir, 'config.json')
+    config_dict = {
+        'shape'      : config.shape,
+        'min_signal' : config.min_signal,
+    }
+
+    with open(config_path, 'wt') as f:
+        json.dump(config_dict, f, indent = 4)
+
+def main():
+    cmdargs = parse_cmdargs()
+    config  = create_config_from_cmdargs(cmdargs)
+
+    if os.path.exists(config.outdir):
+        raise RuntimeError(
+            f"Output directory {config.outdir} exists. Refusing to overwrite."
+        )
+
+    print("Collecting images...")
+    image_hierarchy = collect_split_toyzero_images(config.root)
+    validate_image_hierarchy_paired(image_hierarchy)
+
+    print("Preparing output directories...")
+    prepare_output_directories(config.outdir, image_hierarchy)
+    save_config(config)
+
+    print("Tiling...")
+    tile_images(config, image_hierarchy)
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/toyzero/train_test_split
+++ b/scripts/toyzero/train_test_split
@@ -1,0 +1,206 @@
+#!/usr/bin/env python
+"""Split toyzero images into train/test/val parts"""
+# pylint: disable=missing-function-docstring
+
+import argparse
+import json
+import os
+import multiprocessing
+import shutil
+
+from collections import namedtuple
+
+import numpy as np
+import pandas as pd
+
+import tqdm
+
+from toytools.consts import (
+    DIR_FAKE, DIR_REAL, SPLIT_TRAIN, SPLIT_TEST, SPLIT_VAL
+)
+from toytools.collect import train_val_test_split, collect_toyzero_images
+
+Config = namedtuple(
+    'Config',
+    [ 'root', 'outdir', 'seed', 'shuffle', 'test_size', 'val_size' ]
+)
+
+def parse_cmdargs():
+    parser = argparse.ArgumentParser(
+        "Extract center crops from toyzero dataset"
+    )
+
+    parser.add_argument(
+        'root',
+        help    = 'path to the toyzero dataset',
+        metavar = 'PATH',
+        type    = str,
+    )
+
+    parser.add_argument(
+        'outdir',
+        help    = 'directory where to save cropped dataset',
+        metavar = 'OUTDIR',
+        type    = str,
+    )
+
+    parser.add_argument(
+        '--shuffle',
+        action  = 'store_true',
+        dest    = 'shuffle',
+        help    = 'whether to shuffle data',
+    )
+
+    parser.add_argument(
+        '--seed',
+        default = 0,
+        dest    = 'seed',
+        help    = 'seed of a pseudo random generator',
+        type    = int,
+    )
+
+    parser.add_argument(
+        '--val-size',
+        default = 0,
+        dest    = 'val_size',
+        help    = (
+            'size of the validation dataset. '
+            'If val-size <= 1, then it is interpreted as a fraction'
+        ),
+        type    = float,
+    )
+
+    parser.add_argument(
+        '--test-size',
+        default = 0.2,
+        dest    = 'test_size',
+        help    = (
+            'size of the test dataset. '
+            'If test-size <= 1, then it is interpreted as a fraction'
+        ),
+        type    = float,
+    )
+
+    return parser.parse_args()
+
+class CopyingWorker:
+    # pylint: disable=missing-class-docstring
+
+    def __init__(self, root, outdir_real, outdir_fake):
+        self._root        = root
+        self._outdir_real = outdir_real
+        self._outdir_fake = outdir_fake
+
+    def __call__(self, index_fname):
+        (index, fname) = index_fname
+
+        path_real = os.path.join(self._root, DIR_REAL, fname)
+        path_fake = os.path.join(self._root, DIR_FAKE, fname)
+
+        fname_out = f'sample_{index}.npz'
+
+        shutil.copy(path_real, os.path.join(self._outdir_real, fname_out))
+        shutil.copy(path_fake, os.path.join(self._outdir_fake, fname_out))
+
+        return (index, fname, fname_out)
+
+def create_config_from_cmdargs(cmdargs):
+    return Config(
+        root      = cmdargs.root,
+        outdir    = cmdargs.outdir,
+        seed      = cmdargs.seed,
+        shuffle   = cmdargs.shuffle,
+        test_size = cmdargs.test_size,
+        val_size  = cmdargs.val_size,
+    )
+
+def prepare_image_lists(config):
+    images = collect_toyzero_images(config.root)
+    prg    = np.random.default_rng(config.seed)
+
+    train_indices, val_indices, test_indices = train_val_test_split(
+        len(images), config.val_size, config.test_size, config.shuffle, prg
+    )
+
+    train_images = [ images[i] for i in train_indices ]
+    val_images   = [ images[i] for i in val_indices   ]
+    test_images  = [ images[i] for i in test_indices  ]
+
+    return (train_images, val_images, test_images)
+
+def extract_images(config, split, images, rename_map):
+    outdir_split = os.path.join(config.outdir,  split)
+    outdir_real  = os.path.join(outdir_split,   DIR_REAL)
+    outdir_fake  = os.path.join(outdir_split,   DIR_FAKE)
+
+    os.makedirs(outdir_real, exist_ok = True)
+    os.makedirs(outdir_fake, exist_ok = True)
+
+    progbar = tqdm.tqdm(
+        desc = 'Splitting', total = len(images), dynamic_ncols = True
+    )
+
+    worker = CopyingWorker(config.root, outdir_real, outdir_fake)
+
+    with multiprocessing.Pool() as pool:
+        for (index, fname_src, fname_dst) in pool.imap_unordered(
+            worker, enumerate(images)
+        ):
+            rename_map.append((split, index, fname_dst, fname_src))
+            progbar.update()
+
+    progbar.close()
+
+def save_config(config):
+    config_path = os.path.join(config.outdir, 'config.json')
+    config_dict = {
+        'script'    : 'toyzero/train_test_split',
+        'seed'      : config.seed,
+        'shuffle'   : config.shuffle,
+        'test_size' : config.test_size,
+        'val_size'  : config.val_size,
+    }
+
+    with open(config_path, 'wt') as f:
+        json.dump(config_dict, f, indent = 4)
+
+def save_map(config, rename_map):
+    map_path = os.path.join(config.outdir, 'map.csv')
+
+    rename_map.sort()
+
+    df = pd.DataFrame(
+        rename_map, columns = [ 'split', 'index', 'fname_dest', 'fname_src' ]
+    )
+    df.to_csv(map_path, index = False)
+
+def main():
+    cmdargs = parse_cmdargs()
+    config  = create_config_from_cmdargs(cmdargs)
+
+    if os.path.exists(config.outdir):
+        raise RuntimeError(
+            f"Output directory {config.outdir} exists. Refusing to overwrite."
+        )
+
+    train_images, val_images, test_images = prepare_image_lists(config)
+    rename_map = []
+
+    if len(train_images) > 0:
+        print("Extracting train images...")
+        extract_images(config, SPLIT_TRAIN, train_images, rename_map)
+
+    if len(test_images) > 0:
+        print("Extracting test images...")
+        extract_images(config, SPLIT_TEST, test_images, rename_map)
+
+    if len(val_images) > 0:
+        print("Extracting val images...")
+        extract_images(config, SPLIT_VAL, val_images, rename_map)
+
+    save_config(config)
+    save_map(config, rename_map)
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/train_test_split
+++ b/scripts/train_test_split
@@ -30,7 +30,7 @@ def parse_cmdargs():
         '-s', '--seed',
         default = 0,
         dest    = 'seed',
-        help    = 'Whether to shuffle data',
+        help    = 'seed of the rng',
         type    = int,
     )
 

--- a/toytools/collect.py
+++ b/toytools/collect.py
@@ -161,8 +161,12 @@ def filter_images(
 
     return [ x[0] for x in parsed_images ]
 
-def load_image(root : str, is_fake : bool, name : str) -> np.ndarray:
-    """Load image `name`"""
+#def load_toyzero_image(path : str) -> np.ndarray:
+#    with np.load(path) as f:
+#        return f[f.files[0]]
+
+def load_toyzero_image(root : str, is_fake : bool, name : str) -> np.ndarray:
+    """Load toyzero image `name`"""
 
     if is_fake:
         subdir = DIR_FAKE

--- a/toytools/collect.py
+++ b/toytools/collect.py
@@ -161,9 +161,10 @@ def filter_images(
 
     return [ x[0] for x in parsed_images ]
 
-#def load_toyzero_image(path : str) -> np.ndarray:
-#    with np.load(path) as f:
-#        return f[f.files[0]]
+def load_image(path : str) -> np.ndarray:
+    """Load image from np archive"""
+    with np.load(path) as f:
+        return f[f.files[0]]
 
 def load_toyzero_image(root : str, is_fake : bool, name : str) -> np.ndarray:
     """Load toyzero image `name`"""
@@ -174,9 +175,7 @@ def load_toyzero_image(root : str, is_fake : bool, name : str) -> np.ndarray:
         subdir = DIR_REAL
 
     path = os.path.join(root, subdir, name)
-
-    with np.load(path) as f:
-        return f[f.files[0]]
+    return load_image(path)
 
 def train_val_test_split(
     n         : int,

--- a/toytools/datasets/precropped_toyzero.py
+++ b/toytools/datasets/precropped_toyzero.py
@@ -3,7 +3,8 @@ import os
 import numpy as np
 
 from toytools.collect   import (
-    DIR_FAKE, DIR_REAL, load_image, find_images_in_dir, validate_toyzero_images
+    DIR_FAKE, DIR_REAL, load_toyzero_image, find_images_in_dir,
+    validate_toyzero_images
 )
 from .generic_dataset   import GenericDataset
 
@@ -87,8 +88,8 @@ class PreCroppedToyzeroDataset(GenericDataset):
         fname_fake = self._images_fake[index]
         fname_real = self._images_real[index]
 
-        image_fake = load_image(self._root, True,  fname_fake)
-        image_real = load_image(self._root, False, fname_real)
+        image_fake = load_toyzero_image(self._root, True,  fname_fake)
+        image_real = load_toyzero_image(self._root, False, fname_real)
 
         images = [image_fake,  image_real]
         images = [ x.astype(np.float32) for x in images ]

--- a/toytools/datasets/presimple_toyzero.py
+++ b/toytools/datasets/presimple_toyzero.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import pandas as pd
 
-from toytools.collect   import load_image, train_test_split
+from toytools.collect   import load_toyzero_image, train_test_split
 from toytools.transform import crop_image
 from .generic_dataset   import GenericDataset
 
@@ -85,8 +85,8 @@ class PreSimpleToyzeroDataset(GenericDataset):
     def __getitem__(self, index):
         sample = self._df.iloc[index]
 
-        image_fake = load_image(self._path, True,  sample.image)
-        image_real = load_image(self._path, False, sample.image)
+        image_fake = load_toyzero_image(self._path, True,  sample.image)
+        image_real = load_toyzero_image(self._path, False, sample.image)
 
         crop_region = (sample.x, sample.y, sample.width, sample.height)
 

--- a/toytools/datasets/preunaligned_toyzero.py
+++ b/toytools/datasets/preunaligned_toyzero.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import pandas as pd
 
-from toytools.collect   import load_image, train_test_split
+from toytools.collect   import load_toyzero_image, train_test_split
 from toytools.transform import crop_image
 from .generic_dataset   import GenericDataset
 
@@ -96,8 +96,8 @@ class PreUnalignedToyzeroDataset(GenericDataset):
         sample_fake = self._df_fake.iloc[index]
         sample_real = self._df_real.iloc[index]
 
-        image_fake = load_image(self._path, True,  sample_fake.image)
-        image_real = load_image(self._path, False, sample_real.image)
+        image_fake = load_toyzero_image(self._path, True,  sample_fake.image)
+        image_real = load_toyzero_image(self._path, False, sample_real.image)
 
         images  = [image_fake,  image_real]
         samples = [sample_fake, sample_real]

--- a/toytools/datasets/simple_toyzero.py
+++ b/toytools/datasets/simple_toyzero.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 from toytools.collect   import (
-    collect_toyzero_images, filter_images, load_image, train_test_split
+    collect_toyzero_images, filter_images, load_toyzero_image, train_test_split
 )
 from toytools.transform import (
     get_background_value_fast, crop_image, try_find_region_with_signal
@@ -129,8 +129,8 @@ class SimpleToyzeroDataset(GenericDataset):
             sample_index = self._indices[index % len(self._indices)]
 
         image_name = self._images[sample_index]
-        image_fake = load_image(self._path, True,  image_name)
-        image_real = load_image(self._path, False, image_name)
+        image_fake = load_toyzero_image(self._path, True,  image_name)
+        image_real = load_toyzero_image(self._path, False, image_name)
         bkg_value  = get_background_value_fast(image_fake)
 
         if self._crop_shape is not None:


### PR DESCRIPTION
Hi everyone,

I have revised the previous PR (https://github.com/LS4GAN/toytools/pull/21) that implements new toyzero cropping and tiling scripts, according to the new plan that we have developed. This PR adds three new scripts:

* `scripts/toyzero/center_crop` -- performs center crop extraction, APA and wire plane filtration and removal of empty crops. This script will not rename images and it won't split them into train/test parts.
* `scripts/toyzero/train_test_split` -- this script will split images into training/test parts and also rename them in a sequential manner. That is, the first crop will have name `sample_0.npz`, followed by `sample_1.npz` etc.
* `scripts/toyzero/tile_crop` -- this script will take crops separated into train/test parts and perform their tiling.

@YHRen, I know that you are busy, so please do not bother reviewing this PR if you have other things to attend. I would like to ask you, however, to double check that you agree with the functionality of the new scripts, that I have described above, please.

Inviting: @YHRen, @pphuangyi, @HaiwangYu 